### PR TITLE
Пофиксил букву "p" в перекрестной ссылке

### DIFF
--- a/gost-r-7.0.5-2008/GOST-R-7.0.5-2008-lexicographically.xsl
+++ b/gost-r-7.0.5-2008/GOST-R-7.0.5-2008-lexicographically.xsl
@@ -171,7 +171,7 @@
         <format>[%Tag%]</format>
       </source>
       <source type="Book">
-        <format>{%CitationPrefix%}%BibOrder%{, vol. %CitationVolume%}{, %CitationPages:p. :pp. %}{%CitationSuffix%}</format>
+        <format>{%CitationPrefix%}%BibOrder%{, vol. %CitationVolume%}{, %CitationPages:с. :pp. %}{%CitationSuffix%}</format>
       </source>
       <source type="BookSection">
         <format>{%BibOrder%}</format>


### PR DESCRIPTION
**Проблема**: в перекрестных ссылках используется буква "p" для обозначения страницы вместо "с", когда в списке литературы используются русскоязычные ресурсы.

**Как воспроизвести проблему**:
1. Создайте элемент списка литературы в "Управление источниками", выбрав язык - русский, а стандарт - ГОСТ 2008 (по порядку включения);
2. Вставьте список литературы где-нибудь;
3. Вставьте перекрестную ссылку;
4. Укажите в параметрах перекрестной ссылки отображение страниц;
5. Выйдет буква "p" (page) вместо русской "c"

**Видео**: 
![2017-06-01_14-05-18 1](https://cloud.githubusercontent.com/assets/12271104/26665437/94ce406c-46d4-11e7-9511-b0489dc14fad.gif)

**Конфигурация**:
• Windows 10
• Office 2016

**Решение**: поменять символ на "с" на 174 строке файла.